### PR TITLE
Use env port in Flask run

### DIFF
--- a/app.py
+++ b/app.py
@@ -76,4 +76,4 @@ def download_file(filename):
                      as_attachment=True)
 
 if __name__ == '__main__':
-    app.run(debug=True)
+    app.run(host='0.0.0.0', port=int(os.environ.get('PORT', 5000)))


### PR DESCRIPTION
## Summary
- allow Flask to use port from environment for Render deployment

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68661e24101c832ab08bda2244ae0bbb